### PR TITLE
fix: delete villain from cache

### DIFF
--- a/src/app/villains/villains.component.ts
+++ b/src/app/villains/villains.component.ts
@@ -77,9 +77,8 @@ export class VillainsComponent implements OnInit {
   deleteVillain() {
     this.closeModal();
     if (this.villainToDelete) {
-      this.villainService
-        .delete(this.villainToDelete.id)
-        .subscribe(() => (this.villainToDelete = null));
+      this.villainService.removeOneFromCache(this.villainToDelete.id);
+      this.villainToDelete = null;
     }
     this.clear();
   }


### PR DESCRIPTION
**Problem:**

Ngrx data was returning errors in console on attempt to delete villain from storage (ie. `db.json`).